### PR TITLE
multi ECS cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module
 #### Required
 - `alb_log_bucket` - s3 bucket to send ALB Logs
 - `dns_zone` - Zone where the Consul UI alb will be created. This should *not* be consul.tld.com
-- `ecs_cluster_id` - ARN of the ECS ID
+- `ecs_cluster_ids` - List of ARNs of the ECS Cluster IDs List must contain 1 entry, and can have up to two elements. Currently any elements other then the first two are ignored. 
 - `env` - env to deploy into, should typically dev/staging/prod
 - `join_ec2_tag` - EC2 Tags which consul will search for in order to generate a list of IP's to join. See https://github.com/hashicorp/consul-ec2-auto-join-example for more examples.
 - `subnets` - List of subnets used to deploy the Consul alb

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Consul Cluster terraform module
 
 A terraform module providing an opinionated Consul cluster built on an ECS cluster in AWS.
 
-[![CircleCI](https://circleci.com/gh/FitnessKeeper/terraform-consul-cluster.svg?style=svg)](https://circleci.com/gh/FitnessKeeper/terraform-consul-cluster)
-
 This module is designed to be used in conjunction with the [Runkeeper ECS Module](https://github.com/FitnessKeeper/terraform-ecs)
 
 This module supports consul 0.9.1 or later.
@@ -36,11 +34,10 @@ This module
 #### Optional
 
 - `cluster_size`  - Consul cluster size. This must be greater the 3, defaults to 3
+- `datacenter_name` - Optional overide for datacenter nam
 - `enable_script_checks` - description = This controls whether health checks that execute scripts are enabled on this agent, and defaults to false
-- `hostname` - DNS Hostname for the bastion host. Defaults to ${VPC NAME}.${dns_zone} if hostname is not set, if hostname is set, DNS will be configured to ${hostname}.${dns_zone}
 - `oauth2_proxy_htpasswd_file` - Path the htpasswd file defaults to /conf/htpasswd
 - `join_ec2_tag_key` - EC2 Tag Key which consul uses to search to generate a list of IP's to Join. Defaults to Name
-- `iam_path` - IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /
 - `raft_multiplier" - An integer multiplier used by Consul servers to scale key Raft timing parameters https://www.consul.io/docs/guides/performance.html defaults to 5
 - `region` - AWS Region - defaults to us-east-1
 - `oauth2_proxy_provider` - OAuth provider defaults to github

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "template_file" "consul" {
   template = "${file("${path.module}/files/consul.json")}"
 
   vars {
-    datacenter                 = "${data.aws_vpc.vpc.tags["Name"]}"
+    datacenter                 = "${coalesce(var.datacenter_name ,data.aws_vpc.vpc.tags["Name"])}"
     env                        = "${var.env}"
     enable_script_checks       = "${var.enable_script_checks}"
     enable_script_checks       = "${var.enable_script_checks ? "true" : "false"}"

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_ecs_service" "consul" {
   name            = "consul-${var.env}"
   cluster         = "${var.ecs_cluster_ids[0]}"
   task_definition = "${aws_ecs_task_definition.consul.arn}"
-  desired_count   = "${var.cluster_size * 2}"               # This is not awesome, it lets new AS groups get added to the cluster before destruction.
+  desired_count   = "${var.cluster_size * 2}"                      # This is not awesome, it lets new AS groups get added to the cluster before destruction.
 
   placement_constraints {
     type = "distinctInstance"
@@ -91,7 +91,7 @@ resource "aws_ecs_service" "consul_primary" {
   name            = "consul-${var.env}-primary"
   cluster         = "${var.ecs_cluster_ids[0]}"
   task_definition = "${aws_ecs_task_definition.consul.arn}"
-  desired_count   = "${var.cluster_size * 2 }"  # This is not awesome, it lets new AS groups get added to the cluster before destruction.
+  desired_count   = "${var.cluster_size * 2 }"                    # This is not awesome, it lets new AS groups get added to the cluster before destruction.
 
   placement_constraints {
     type = "distinctInstance"
@@ -117,7 +117,7 @@ resource "aws_ecs_service" "consul_secondary" {
   name            = "consul-${var.env}-secondary"
   cluster         = "${var.ecs_cluster_ids[1]}"
   task_definition = "${aws_ecs_task_definition.consul.arn}"
-  desired_count   = "${var.cluster_size * 2 }"  # This is not awesome, it lets new AS groups get added to the cluster before destruction.
+  desired_count   = "${var.cluster_size * 2 }"                    # This is not awesome, it lets new AS groups get added to the cluster before destruction.
 
   placement_constraints {
     type = "distinctInstance"

--- a/main.tf
+++ b/main.tf
@@ -59,9 +59,11 @@ resource "aws_cloudwatch_log_group" "consul" {
   }
 }
 
+# start service
 resource "aws_ecs_service" "consul" {
+  count           = "${length(var.ecs_cluster_ids)  == 1 ? 1 : 0}"
   name            = "consul-${var.env}"
-  cluster         = "${var.ecs_cluster_id}"
+  cluster         = "${var.ecs_cluster_ids[0]}"
   task_definition = "${aws_ecs_task_definition.consul.arn}"
   desired_count   = "${var.cluster_size * 2}"               # This is not awesome, it lets new AS groups get added to the cluster before destruction.
 
@@ -84,6 +86,59 @@ resource "aws_ecs_service" "consul" {
   ]
 }
 
+resource "aws_ecs_service" "consul_primary" {
+  count           = "${length(var.ecs_cluster_ids)  > 1 ? 1 : 0}"
+  name            = "consul-${var.env}-primary"
+  cluster         = "${var.ecs_cluster_ids[0]}"
+  task_definition = "${aws_ecs_task_definition.consul.arn}"
+  desired_count   = "${var.cluster_size * 2 }"  # This is not awesome, it lets new AS groups get added to the cluster before destruction.
+
+  placement_constraints {
+    type = "distinctInstance"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.consul_ui.arn}"
+    container_name   = "consul-ui-${var.env}"
+    container_port   = 4180
+  }
+
+  iam_role = "${aws_iam_role.ecsServiceRole.arn}"
+
+  depends_on = ["aws_alb_target_group.consul_ui",
+    "aws_alb_listener.consul_https",
+    "aws_alb.consul",
+    "aws_iam_role.ecsServiceRole",
+  ]
+}
+
+resource "aws_ecs_service" "consul_secondary" {
+  count           = "${length(var.ecs_cluster_ids)  > 1 ? 1 : 0}"
+  name            = "consul-${var.env}-secondary"
+  cluster         = "${var.ecs_cluster_ids[1]}"
+  task_definition = "${aws_ecs_task_definition.consul.arn}"
+  desired_count   = "${var.cluster_size * 2 }"  # This is not awesome, it lets new AS groups get added to the cluster before destruction.
+
+  placement_constraints {
+    type = "distinctInstance"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.consul_ui.arn}"
+    container_name   = "consul-ui-${var.env}"
+    container_port   = 4180
+  }
+
+  iam_role = "${aws_iam_role.ecsServiceRole.arn}"
+
+  depends_on = ["aws_alb_target_group.consul_ui",
+    "aws_alb_listener.consul_https",
+    "aws_alb.consul",
+    "aws_iam_role.ecsServiceRole",
+  ]
+}
+
+# end service
 # Security Groups
 resource "aws_security_group" "alb-web-sg" {
   name        = "tf-${data.aws_vpc.vpc.tags["Name"]}-consul-uiSecurityGroup"

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "consul_image" {
   default     = "fitnesskeeper/consul:latest"
 }
 
+variable "datacenter_name" {
+  description = "Optional overide for datacenter name"
+  default     = ""
+}
+
 variable "dns_zone" {
   description = "Zone where the Consul UI alb will be created. This should *not* be consul.example.com"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,8 +21,9 @@ variable "dns_zone" {
   description = "Zone where the Consul UI alb will be created. This should *not* be consul.example.com"
 }
 
-variable "ecs_cluster_id" {
-  description = "ARN of the ECS ID"
+variable "ecs_cluster_ids" {
+  type        = "list"
+  description = "List of ARNs of the ECS Cluster IDs"
 }
 
 variable "env" {}


### PR DESCRIPTION
This PR should address the race condition we sometimes see when redeploying AMI's under the autoscaling groups in an ECS Cluster.  That is do say, you can now spread consul across multiple ECS clusters, and pin those clusters to particular AMI's, upgrading them one at a time, which will allow consul to keep not loose it's mind as nodes disappear out from under it. 

This PR *does not* address  the issue of rolling updates across the *services* since it still uses the `desired_count   = "${var.cluster_size * 2}" ` logic to ensure that tasks get deployed as new ASG's and AMI's are deployed - changing this in testing to `desired_count   = "${var.cluster_size}" ` didn't work, as although the tasks were spread across both ASG's when ASG one goes down, there isn't anything triggering new tasks to *grow* the cluster. Solving this problem started becoming a rat hole and I felt like I could solve the problem we actually had and loop back to the task problem later. 