### PR TITLE
feat: add lb_deregistration_delay variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This module supports two modes. If you pass a single ECS cluster ID into the `ec
 - `oauth2_proxy_provider` - OAuth provider defaults to github
 - `oauth2_proxy_github_team` - list of teams that should have access defaults to empty list (allow all)
 - `service_minimum_healthy_percent` - The minimum healthy percent represents a lower limit on the number of your service's tasks that must remain in the RUNNING state during a deployment
-- `alb_deregistration_delay` - The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
+- `lb_deregistration_delay` - The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This module supports two modes. If you pass a single ECS cluster ID into the `ec
 - `oauth2_proxy_provider` - OAuth provider defaults to github
 - `oauth2_proxy_github_team` - list of teams that should have access defaults to empty list (allow all)
 - `service_minimum_healthy_percent` - The minimum healthy percent represents a lower limit on the number of your service's tasks that must remain in the RUNNING state during a deployment
+- `alb_deregistration_delay` - The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 
 Usage
 -----

--- a/alb.tf
+++ b/alb.tf
@@ -44,6 +44,7 @@ resource "aws_alb_target_group" "consul_ui" {
   port     = 4180
   protocol = "HTTP"
   vpc_id   = "${data.aws_vpc.vpc.id}"
+  deregistration_delay = "${var.alb_deregistration_delay}"
 
   health_check {
     path    = "/ping"

--- a/alb.tf
+++ b/alb.tf
@@ -41,9 +41,9 @@ resource "aws_route53_record" "consul" {
 
 # Create a new target group
 resource "aws_alb_target_group" "consul_ui" {
-  port     = 4180
-  protocol = "HTTP"
-  vpc_id   = "${data.aws_vpc.vpc.id}"
+  port                 = 4180
+  protocol             = "HTTP"
+  vpc_id               = "${data.aws_vpc.vpc.id}"
   deregistration_delay = "${var.alb_deregistration_delay}"
 
   health_check {

--- a/alb.tf
+++ b/alb.tf
@@ -44,7 +44,7 @@ resource "aws_alb_target_group" "consul_ui" {
   port                 = 4180
   protocol             = "HTTP"
   vpc_id               = "${data.aws_vpc.vpc.id}"
-  deregistration_delay = "${var.alb_deregistration_delay}"
+  deregistration_delay = "${var.lb_deregistration_delay}"
 
   health_check {
     path    = "/ping"

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "alb_log_bucket" {
 
 variable "lb_deregistration_delay" {
   description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds."
-  default     = 300
+  default     = "300"
 }
 
 variable "cloudwatch_log_retention" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "alb_log_bucket" {
   description = "s3 bucket to send ALB Logs"
 }
 
-variable "alb_deregistration_delay" {
+variable "lb_deregistration_delay" {
   description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds."
   default     = 300
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "alb_log_bucket" {
   description = "s3 bucket to send ALB Logs"
 }
 
+variable "alb_deregistration_delay" {
+  description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds."
+  default     = 300
+}
+
 variable "cloudwatch_log_retention" {
   default     = "30"
   description = "Specifies the number of days you want to retain log events in the specified log group. (defaults to 30)"


### PR DESCRIPTION
This allows users of this module to optionally reduce the time required to cycle all ECS containers, for instance when cycling the underlying ECS cluster.

Note that by default this maintains the AWS default of 300 seconds.