### PR TITLE
feat: add leave_on_terminate (default true so containers gracefully leave when ECS stops the task)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ Session.vim
 # auto-generated tag files
 tags
 
-
+# editors
+.idea

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This module supports two modes. If you pass a single ECS cluster ID into the `ec
 - `oauth2_proxy_htpasswd_file` - Path the htpasswd file defaults to /conf/htpasswd
 - `join_ec2_tag_key` - EC2 Tag Key which consul uses to search to generate a list of IP's to Join. Defaults to Name
 - `raft_multiplier" - An integer multiplier used by Consul servers to scale key Raft timing parameters https://www.consul.io/docs/guides/performance.html defaults to 5
+- `leave_on_terminate` - If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to false.
 - `region` - AWS Region - defaults to us-east-1
 - `registrator_image` - Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest image
 - `registrator_memory_reservation` The soft limit (in MiB) of memory to reserve for the container, defaults 32

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This module supports two modes. If you pass a single ECS cluster ID into the `ec
 - `oauth2_proxy_htpasswd_file` - Path the htpasswd file defaults to /conf/htpasswd
 - `join_ec2_tag_key` - EC2 Tag Key which consul uses to search to generate a list of IP's to Join. Defaults to Name
 - `raft_multiplier" - An integer multiplier used by Consul servers to scale key Raft timing parameters https://www.consul.io/docs/guides/performance.html defaults to 5
-- `leave_on_terminate` - If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to false.
+- `leave_on_terminate` - If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to true in this module so that containers will gracefully leave the consul cluster when ECS stops the task.
 - `region` - AWS Region - defaults to us-east-1
 - `registrator_image` - Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest image
 - `registrator_memory_reservation` The soft limit (in MiB) of memory to reserve for the container, defaults 32

--- a/files/consul.json
+++ b/files/consul.json
@@ -8,7 +8,7 @@
             "environment": [
                 {
                     "name": "CONSUL_LOCAL_CONFIG",
-                    "value": "{ \"retry_join\": [\"provider=aws tag_key=${join_ec2_tag_key} tag_value=${join_ec2_tag}\"], \"raft_protocol\": 3, \"skip_leave_on_interrupt\": true, \"enable_script_checks\": ${enable_script_checks}, \"datacenter\":\"${datacenter}\", \"performance\": { \"raft_multiplier\": ${raft_multiplier} }}"
+                    "value": "{ \"retry_join\": [\"provider=aws tag_key=${join_ec2_tag_key} tag_value=${join_ec2_tag}\"], \"raft_protocol\": 3, \"skip_leave_on_interrupt\": true, \"leave_on_terminate\": ${leave_on_terminate}, \"enable_script_checks\": ${enable_script_checks}, \"datacenter\":\"${datacenter}\", \"performance\": { \"raft_multiplier\": ${raft_multiplier} }}"
                 },
                 {
                     "name": "CONSUL_BIND_INTERFACE",

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ data "template_file" "consul" {
     oauth2_proxy_client_id         = "${var.oauth2_proxy_client_id}"
     oauth2_proxy_client_secret     = "${var.oauth2_proxy_client_secret}"
     raft_multiplier                = "${var.raft_multiplier}"
+    leave_on_terminate             = "${var.leave_on_terminate}"
     s3_backup_bucket               = "${var.s3_backup_bucket}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ data "template_file" "consul" {
     oauth2_proxy_client_id         = "${var.oauth2_proxy_client_id}"
     oauth2_proxy_client_secret     = "${var.oauth2_proxy_client_secret}"
     raft_multiplier                = "${var.raft_multiplier}"
-    leave_on_terminate             = "${var.leave_on_terminate}"
+    leave_on_terminate             = "${var.leave_on_terminate ? "true" : "false"}"
     s3_backup_bucket               = "${var.s3_backup_bucket}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,11 @@ variable "service_minimum_healthy_percent" {
   default     = "66"
 }
 
+variable "leave_on_terminate" {
+  description = "If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to false"
+  default     = false
+}
+
 variable "vpc_id" {}
 
 variable "sha_htpasswd_hash" {

--- a/variables.tf
+++ b/variables.tf
@@ -120,8 +120,8 @@ variable "service_minimum_healthy_percent" {
 }
 
 variable "leave_on_terminate" {
-  description = "If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to false"
-  default     = false
+  description = "If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to true"
+  default     = true
 }
 
 variable "vpc_id" {}

--- a/variables.tf
+++ b/variables.tf
@@ -120,7 +120,7 @@ variable "service_minimum_healthy_percent" {
 }
 
 variable "leave_on_terminate" {
-  description = "If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to true"
+  description = "If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. Defaults to true in this module so that containers will gracefully leave the consul cluster when ECS stops the task."
   default     = true
 }
 


### PR DESCRIPTION
The consul default for `leave_on_terminate` is `false`; however running consul in docker means we need to set this to `true`: when the docker container exits, local data in the container is lost; therefore we need to send a graceful leave before exiting. Docker stop (and ECS Stop Task) send a TERM.

Note that without `leave_on_terminate` set to `true`, when ECS stops a consul task the cluster does still convert the node from `failed` to `left` via Forced Leave; however it would be preferred to send a graceful leave and not rely on the Forced leave.